### PR TITLE
Added config file

### DIFF
--- a/RealRadio.Plugin.ML/MLMod.cs
+++ b/RealRadio.Plugin.ML/MLMod.cs
@@ -1,4 +1,8 @@
+using System;
+using System.IO;
 using MelonLoader;
+using MelonLoader.Preferences;
+using MelonLoader.Utils;
 using RealRadio;
 
 [assembly: MelonInfo(typeof(RealRadio.Plugin.ML.MLMod), MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION, author: "Skipcast")]
@@ -15,6 +19,7 @@ public class MLMod : MelonMod
     public override void OnInitializeMelon()
     {
         Logger.OnLog += OnLog;
+        InitConfig();
 
         plugin = new RealRadioPlugin();
     }
@@ -38,6 +43,71 @@ public class MLMod : MelonMod
             case Logger.LogLevel.Error:
                 log.Error(data);
                 break;
+        }
+    }
+
+    private void InitConfig()
+    {
+        var category = MelonPreferences.CreateCategory(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME);
+        category.SetFilePath(Path.Combine(MelonEnvironment.UserDataDirectory, "RealRadio.cfg"));
+        Config.Instance = new MLConfig(category);
+    }
+
+    class MLConfig : IConfig
+    {
+        public IConfigData Data { get; internal set; }
+
+        public event Action<string, IConfigData>? ValueChanged;
+
+        internal readonly MelonPreferences_Category Category;
+
+        public MLConfig(MelonPreferences_Category category)
+        {
+            Category = category;
+            Data = new MLConfigData(this);
+        }
+
+        internal void OnValueChanged(string propertyName)
+        {
+            ValueChanged?.Invoke(propertyName, Data);
+        }
+    }
+
+    private class MLConfigData : IConfigData
+    {
+        private readonly MelonPreferences_Entry<float> maxAudioHostInactivityTimeEntry;
+        private readonly MelonPreferences_Entry<uint> maxInaudibleAudioClientsEntry;
+
+        public MLConfigData(MLConfig config)
+        {
+            maxAudioHostInactivityTimeEntry = config.Category.CreateEntry<float>(
+                nameof(MaxAudioHostInactivityTime),
+                default_value: 30,
+                display_name: "Max audio host inactivity time",
+                description: "The maximum amount of time (in seconds) that an audio host can be inactive (no audible sound sources) before being stopped.",
+                validator: new ValueRange<float>(0, uint.MaxValue)
+            );
+            maxInaudibleAudioClientsEntry = config.Category.CreateEntry<uint>(
+                nameof(MaxInactiveAudioHosts),
+                default_value: 5,
+                display_name: "Max inaudible audio hosts",
+                description: "The maximum number of audio hosts that can be inactive (not audible) before stopping the least recently played host.",
+                validator: new ValueRange<uint>(0, uint.MaxValue)
+            );
+
+            maxAudioHostInactivityTimeEntry.OnEntryValueChanged.Subscribe((_, _) => config.OnValueChanged(nameof(MaxAudioHostInactivityTime)));
+            maxInaudibleAudioClientsEntry.OnEntryValueChanged.Subscribe((_, _) => config.OnValueChanged(nameof(MaxInactiveAudioHosts)));
+        }
+
+        public float MaxAudioHostInactivityTime
+        {
+            get => maxAudioHostInactivityTimeEntry.Value;
+            set => maxAudioHostInactivityTimeEntry.Value = value;
+        }
+        public uint MaxInactiveAudioHosts
+        {
+            get => maxInaudibleAudioClientsEntry.Value;
+            set => maxInaudibleAudioClientsEntry.Value = value;
         }
     }
 }

--- a/RealRadio.Plugin.ML/MLMod.cs
+++ b/RealRadio.Plugin.ML/MLMod.cs
@@ -49,8 +49,9 @@ public class MLMod : MelonMod
     private void InitConfig()
     {
         var category = MelonPreferences.CreateCategory(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME);
-        category.SetFilePath(Path.Combine(MelonEnvironment.UserDataDirectory, "RealRadio.cfg"));
+        category.SetFilePath(Path.Combine(MelonEnvironment.UserDataDirectory, "RealRadio.cfg"), autoload: false);
         Config.Instance = new MLConfig(category);
+        category.LoadFromFile();
     }
 
     class MLConfig : IConfig

--- a/RealRadio/Components/Audio/AudioStreamManager.cs
+++ b/RealRadio/Components/Audio/AudioStreamManager.cs
@@ -13,8 +13,6 @@ public class AudioStreamManager : MonoBehaviour
 {
     public IReadOnlyCollection<StreamAudioHost> Hosts => hosts.Values;
 
-    public uint MaxActiveInaudibleHosts = 5;
-
     public int NumActiveHosts => activeHosts.Count;
 
     private Dictionary<string, StreamAudioHost> hosts = new();
@@ -23,6 +21,8 @@ public class AudioStreamManager : MonoBehaviour
 
     public static AudioStreamManager Instance => GetOrInitInstance();
     private static AudioStreamManager? cachedInstance;
+
+    private uint MaxActiveInaudibleHosts => Config.Instance.Data.MaxInactiveAudioHosts;
 
     private static AudioStreamManager GetOrInitInstance()
     {

--- a/RealRadio/Components/Audio/StreamAudioHost.cs
+++ b/RealRadio/Components/Audio/StreamAudioHost.cs
@@ -15,7 +15,7 @@ public class StreamAudioHost : MonoBehaviour
     public IReadOnlyCollection<StreamAudioClient> ActiveClients => enabledClients;
     public IReadOnlyCollection<StreamAudioClient> SpawnedClients => spawnedClients;
 
-    public float MaxClientInactivityTime = 30f;
+    private float MaxInactivityTime => Config.Instance.Data.MaxAudioHostInactivityTime;
 
     public int NumActiveClients => enabledClients.Count;
 
@@ -153,7 +153,7 @@ public class StreamAudioHost : MonoBehaviour
         {
             inactiveTimer += Time.unscaledDeltaTime;
 
-            if (inactiveTimer >= MaxClientInactivityTime)
+            if (inactiveTimer >= MaxInactivityTime)
             {
                 Logger.LogDebug("Stopping audio stream host due to inactivity");
                 StopAudioStream();
@@ -342,7 +342,7 @@ public class StreamAudioHost : MonoBehaviour
     {
         readingAudioData = true;
 
-        if (AudioStream == null || !AudioStream.StreamAvailable || stopRequested || streamEnded == true || inactiveTimer >= MaxClientInactivityTime)
+        if (AudioStream == null || !AudioStream.StreamAvailable || stopRequested || streamEnded == true || inactiveTimer >= MaxInactivityTime)
         {
             readingAudioData = false;
             return;

--- a/RealRadio/Config.cs
+++ b/RealRadio/Config.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace RealRadio;
+
+public static class Config
+{
+    public static IConfig Instance
+    {
+        get => instance ?? throw new InvalidOperationException("Config has not been set");
+        internal set => instance = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    private static IConfig? instance;
+}
+
+public interface IConfigData
+{
+    public float MaxAudioHostInactivityTime { get; set; }
+    public uint MaxInactiveAudioHosts { get; set; }
+}
+
+public interface IConfig
+{
+    event Action<string, IConfigData>? ValueChanged;
+
+    IConfigData Data { get; }
+}


### PR DESCRIPTION
Allows configuring the following values:
- MaxAudioHostInactivityTime: The maximum amount of time (in seconds) that an audio host can be inactive (no audible sound sources) before being stopped.
- MaxInactiveAudioHosts: The maximum number of audio hosts that can be inactive (not audible) before stopping the least recently played host.