### PR TITLE
Downgrade MelonLoader dependency to 0.7.0

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -69,7 +69,7 @@ jobs:
                           "version_number": "${{ steps.realradio_version.outputs.version }}",
                           "website_url": "https://github.com/Skippeh/Schedule1RealRadioMod",
                           "dependencies": [
-                            "LavaGang-MelonLoader-0.7.1"
+                            "LavaGang-MelonLoader-0.7.0"
                           ]
                       }
             - name: Upload artifact (MelonLoader Thunderstore)

--- a/LocalMultiplayer/LocalMultiplayer.csproj
+++ b/LocalMultiplayer/LocalMultiplayer.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(MELONLOADER)' != ''">
-    <PackageReference Include="LavaGang.MelonLoader" Version="0.7.1" />
+    <PackageReference Include="LavaGang.MelonLoader" Version="0.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RealRadio.Plugin.ML/RealRadio.Plugin.ML.csproj
+++ b/RealRadio.Plugin.ML/RealRadio.Plugin.ML.csproj
@@ -21,7 +21,7 @@
   <Import Project="$(SolutionDir)build_targets\CopyPlugin.targets" />
 
   <ItemGroup>
-    <PackageReference Include="LavaGang.MelonLoader" Version="0.7.1" />
+    <PackageReference Include="LavaGang.MelonLoader" Version="0.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build_targets/CopyPlugin.targets
+++ b/build_targets/CopyPlugin.targets
@@ -36,6 +36,9 @@
 
     <Message Importance="high" Text="Copying $(AssemblyName) asset files to plugin folder: $(Destination)" />
     <Copy SourceFiles="@(AssetFiles)" DestinationFiles="@(AssetFiles->'$(Destination)\Assets\%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <!-- Create manifest.json file for melonloader. Default behavior in ML 0.7.0 is to not search subfolders for mods unless they have a manifest.json file in them. -->
+     <Touch AlwaysCreate="true" Files="%(PluginFolder.Identity)\$(PluginDirectory)\manifest.json" Condition="'$(MELONLOADER)' != ''" />
   </Target>
 
   <Target Name="CopyToUnityProject" AfterTargets="PostBuildEvent" Condition="'$(CI)' == '' And '$(CopyFiles)' == 'true' And '$(CopyToUnity)' == 'true'">
@@ -54,5 +57,8 @@
     <Copy SourceFiles="@(CopyToPluginFolder)" DestinationFiles="@(CopyToPluginFolder->'$(Destination)\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Message Importance="high" Text="Copying $(AssemblyName) asset files to dist folder: $(DistDestination)" />
     <Copy SourceFiles="@(AssetFiles)" DestinationFiles="@(AssetFiles->'$(Destination)\Assets\%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <!-- Create manifest.json file for melonloader. Default behavior in ML 0.7.0 is to not search subfolders for mods unless they have a manifest.json file in them. -->
+     <Touch AlwaysCreate="true" Files="$(Destination)\manifest.json" Condition="'$(MELONLOADER)' != ''" />
   </Target>
 </Project>


### PR DESCRIPTION
- Downgrade MelonLoader dependencies to 0.7.0 (mod is still compatible with 0.7.1, but this helps with compatibility with other mods due to some mods being brokey on 0.7.1)
- Add a dummy manifest.json file in the RealRadio plugin folder. ML 0.7.0 does not search subfolders for mods by default unless there's a manifest.json file in it.